### PR TITLE
feat: return 401 for invalid login and map password field

### DIFF
--- a/docs/api.apib
+++ b/docs/api.apib
@@ -8,6 +8,16 @@ FORMAT: 1A
 + Response 201 (application/json)
     + Attributes (UserResponse)
 
+# Group Auth
+## Login [POST /api/v1/auth/login]
++ Request (application/json)
+    + Attributes (LoginRequest)
++ Response 200 (application/json)
+    + Attributes
+        + authenticated: true (boolean)
++ Response 401 (application/json)
+    + Attributes (ErrorResponse)
+
 # Data Structures
 ## UserRequest (object)
 + name: John Doe (string, required)
@@ -15,3 +25,10 @@ FORMAT: 1A
 + login: jdoe (string, required)
 + password: s3cret (string, required)
 + role: CLIENT (enum[string])
+
+## LoginRequest (object)
++ login: jdoe (string, required)
++ password: s3cret (string, required)
+
+## ErrorResponse (object)
++ error: Invalid credentials (string)

--- a/src/main/java/com/example/users/api/AuthController.java
+++ b/src/main/java/com/example/users/api/AuthController.java
@@ -1,8 +1,10 @@
 package com.example.users.api;
 import com.example.users.service.UserService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -18,15 +20,18 @@ public class AuthController {
   public record ChangePasswordRequest(@NotBlank String currentPassword, @NotBlank String newPassword, @NotBlank String confirmPassword) {}
 
   @PostMapping("/login")
-  public Map<String,Object> login(@RequestBody LoginRequest req) {
+  public ResponseEntity<Map<String,Object>> login(@Valid @RequestBody LoginRequest req) {
     boolean ok = service.matchesCredentials(req.login(), req.password());
-    if (!ok) return Map.of("error", "Invalid credentials"); // generic; does not reveal details
-    return Map.of("authenticated", true);
+    if (!ok) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                           .body(Map.of("error", "Invalid credentials"));
+    }
+    return ResponseEntity.ok(Map.of("authenticated", true));
   }
 
   @PostMapping("/users/{id}/change-password")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void change(@PathVariable UUID id, @RequestBody ChangePasswordRequest req) {
+  public void change(@PathVariable UUID id, @Valid @RequestBody ChangePasswordRequest req) {
     if (!req.newPassword().equals(req.confirmPassword()))
       throw new RuntimeException("Invalid credentials");
     service.changePassword(id, req.currentPassword(), req.newPassword());

--- a/src/main/java/com/example/users/api/UsersController.java
+++ b/src/main/java/com/example/users/api/UsersController.java
@@ -24,7 +24,6 @@ public class UsersController {
   @ResponseStatus(HttpStatus.CREATED)
   public UserResponse create(@Valid @RequestBody UserRequest req) {
     User u = mapper.toEntity(req);
-    u.setPasswordHash(req.password()); // will be hashed in the service
     return mapper.toResponse(service.create(u));
   }
 

--- a/src/main/java/com/example/users/api/mapper/UserMapper.java
+++ b/src/main/java/com/example/users/api/mapper/UserMapper.java
@@ -5,6 +5,11 @@ import com.example.users.api.dto.*;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "passwordHash", source = "password")
+  @Mapping(target = "lastModifiedAt", ignore = true)
+  @Mapping(target = "active", ignore = true)
   User toEntity(UserRequest req);
+
   UserResponse toResponse(User entity);
 }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -20,7 +20,9 @@ paths:
     post:
       summary: Fake login
       requestBody: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/LoginRequest' }}}}
-      responses: { "200": { description: OK }}
+      responses:
+        "200": { description: OK }
+        "401": { description: Unauthorized }
 
   /api/v1/auth/users/{id}/change-password:
     post:

--- a/src/test/java/com/example/users/service/UserServiceTest.java
+++ b/src/test/java/com/example/users/service/UserServiceTest.java
@@ -1,10 +1,77 @@
 package com.example.users.service;
-import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.Test;
 
-public class UserServiceTest {
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.example.users.domain.User;
+import com.example.users.repo.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock
+  private UserRepository repo;
+
+  @InjectMocks
+  private UserService service;
+
+  private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
   @Test
-  void dummy() {
-    assertTrue(true);
+  void matchesCredentialsReturnsTrue() {
+    var user = User.builder()
+        .id(UUID.randomUUID())
+        .login("john")
+        .passwordHash(encoder.encode("pwd"))
+        .build();
+    when(repo.findByLogin("john")).thenReturn(Optional.of(user));
+
+    assertTrue(service.matchesCredentials("john", "pwd"));
+  }
+
+  @Test
+  void matchesCredentialsReturnsFalseWhenUserMissing() {
+    when(repo.findByLogin("john")).thenReturn(Optional.empty());
+
+    assertFalse(service.matchesCredentials("john", "pwd"));
+  }
+
+  @Test
+  void changePasswordUpdatesHash() {
+    UUID id = UUID.randomUUID();
+    var user = User.builder()
+        .id(id)
+        .passwordHash(encoder.encode("old"))
+        .build();
+    when(repo.findById(id)).thenReturn(Optional.of(user));
+    when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    service.changePassword(id, "old", "newPwd");
+
+    verify(repo).save(argThat(saved -> encoder.matches("newPwd", saved.getPasswordHash())));
+  }
+
+  @Test
+  void changePasswordThrowsWhenCurrentInvalid() {
+    UUID id = UUID.randomUUID();
+    var user = User.builder()
+        .id(id)
+        .passwordHash(encoder.encode("old"))
+        .build();
+    when(repo.findById(id)).thenReturn(Optional.of(user));
+
+    assertThrows(RuntimeException.class, () -> service.changePassword(id, "wrong", "new"));
+    verify(repo, never()).save(any());
   }
 }
+


### PR DESCRIPTION
## Summary
- handle invalid logins with 401 responses and map password to hash via MapStruct
- expand API docs to describe auth login error cases
- add service tests covering credential matching and password changes

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0df2e4a8832d9b09ca5bc0087f61